### PR TITLE
Add simple PDF redaction placeholder

### DIFF
--- a/llm_expts/__init__.py
+++ b/llm_expts/__init__.py
@@ -1,0 +1,6 @@
+"""Utilities for working with PDFs and other experiments."""
+from __future__ import annotations
+
+from .pdf_redactor import redact_pdf
+
+__all__ = ["redact_pdf"]

--- a/llm_expts/pdf_redactor/__init__.py
+++ b/llm_expts/pdf_redactor/__init__.py
@@ -1,0 +1,39 @@
+"""Utility functions for redacting PDF files."""
+
+from __future__ import annotations
+
+import fitz  # PyMuPDF
+
+
+def identify_redactable_substrings(text: str) -> list[str]:
+    """Identify parts of ``text`` that should be redacted.
+
+    This placeholder implementation simply redacts any word that is entirely
+    numeric.  It can be replaced with more sophisticated logic if needed.
+    """
+    words = text.split()
+    numbers = {word for word in words if word.isdigit()}
+    return sorted(numbers)
+
+
+def redact_pdf(input_path: str, output_path: str) -> None:
+    """Redact the given PDF and write the result to ``output_path``.
+
+    Parameters
+    ----------
+    input_path:
+        Path to the PDF that should be processed.
+    output_path:
+        Path where the redacted PDF should be written.
+    """
+
+    document = fitz.open(input_path)
+    for page in document:
+        text = page.get_text()
+        substrings = identify_redactable_substrings(text)
+        for substring in substrings:
+            for inst in page.search_for(substring):
+                page.add_redact_annot(inst, fill=(0, 0, 0))
+        page.apply_redactions()
+
+    document.save(output_path, garbage=4, deflate=True)


### PR DESCRIPTION
## Summary
- add numeric placeholder logic for PDF redaction

## Testing
- `ruff check llm_expts/pdf_redactor/__init__.py`
- `ruff check llm_expts/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68436564d77483269396ad36c33dffcd